### PR TITLE
Edit of the code

### DIFF
--- a/app/src/main/java/fr/uge/wordrawidx/controller/AccelerometerMazeController.kt
+++ b/app/src/main/java/fr/uge/wordrawidx/controller/AccelerometerMazeController.kt
@@ -42,6 +42,7 @@ class AccelerometerMazeController(
     private var targetRadiusPx: Float = 0f
     private var cellWidthPx: Float = 0f
     private var cellHeightPx: Float = 0f
+    private var dimensionsInitialized = false
 
     fun registerListener() {
         accelerometer?.also { accel ->
@@ -62,6 +63,8 @@ class AccelerometerMazeController(
             return
         }
         screenWidthPx = widthPx
+        val oldCellWidth = cellWidthPx
+        val oldCellHeight = cellHeightPx
         screenHeightPx = heightPx
         ballRadiusPx = ballRpx
         targetRadiusPx = targetRpx
@@ -82,10 +85,25 @@ class AccelerometerMazeController(
             cellHeightPx = if (cellHeightPx <= 0) 1f else cellHeightPx
         }
 
-        val initialBallX = DEFAULT_BALL_START_POSITION_GRID_UNITS.x * cellWidthPx
-        val initialBallY = DEFAULT_BALL_START_POSITION_GRID_UNITS.y * cellHeightPx
-        mazeState.ballPosition = Offset(initialBallX, initialBallY)
-        Log.d("MazeController", "Dimensions set. Initial Ball Pos (px): ${mazeState.ballPosition}, cellW: $cellWidthPx, cellH: $cellHeightPx")
+//        val initialBallX = DEFAULT_BALL_START_POSITION_GRID_UNITS.x * cellWidthPx
+//        val initialBallY = DEFAULT_BALL_START_POSITION_GRID_UNITS.y * cellHeightPx
+//        mazeState.ballPosition = Offset(initialBallX, initialBallY)
+//        Log.d("MazeController", "Dimensions set. Initial Ball Pos (px): ${mazeState.ballPosition}, cellW: $cellWidthPx, cellH: $cellHeightPx")
+          if (dimensionsInitialized && oldCellWidth > 0f && oldCellHeight > 0f) {
+                        // On convertit l’ancienne position en unités de grille, puis on la
+                        // reprojette dans les nouvelles dimensions d’écran.
+                        val gridX = mazeState.ballPosition.x / oldCellWidth
+                        val gridY = mazeState.ballPosition.y / oldCellHeight
+                        mazeState.ballPosition = Offset(gridX * cellWidthPx, gridY * cellHeightPx)
+                        Log.d("MazeController", "Rotation : bille recalculée (grid=[$gridX,$gridY]) => px=${mazeState.ballPosition}")
+          } else {
+             // Première initialisation ou valeurs invalides : on part du départ.
+             val initialBallX = DEFAULT_BALL_START_POSITION_GRID_UNITS.x * cellWidthPx
+             val initialBallY = DEFAULT_BALL_START_POSITION_GRID_UNITS.y * cellHeightPx
+             mazeState.ballPosition = Offset(initialBallX, initialBallY)
+             dimensionsInitialized = true
+             Log.d("MazeController","Init : bille placée au départ px=${mazeState.ballPosition}")
+          }
     }
 
 //    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)

--- a/app/src/main/java/fr/uge/wordrawidx/view/screens/AccelerometerMazeScreen.kt
+++ b/app/src/main/java/fr/uge/wordrawidx/view/screens/AccelerometerMazeScreen.kt
@@ -37,6 +37,8 @@ import fr.uge.wordrawidx.R
 import fr.uge.wordrawidx.controller.AccelerometerMazeController
 import fr.uge.wordrawidx.controller.NavigationController
 import fr.uge.wordrawidx.model.*
+import androidx.lifecycle.viewmodel.compose.viewModel;
+import fr.uge.wordrawidx.viewmodel.MazeGameViewModel;
 
 // Constantes pour le mini-jeu labyrinthe
 val MAZE_BALL_IMAGE_SIZE_DP: Dp = 50.dp
@@ -56,7 +58,10 @@ fun AccelerometerMazeScreen(
     val orientation = configuration.orientation
 
     // État du labyrinthe (peut être sauvegardé avec Saver si nécessaire)
-    val mazeState = remember { MazeState() }
+//    val mazeState = remember { MazeState() }
+    // ViewModel qui survit aux changements de configuration
+    val mazeViewModel: MazeGameViewModel = viewModel()
+    val mazeState = mazeViewModel.mazeState
 
     // Contrôleur pour gérer l'accéléromètre et la logique de jeu
     val controller = remember(mazeState, coroutineScope) {

--- a/app/src/main/java/fr/uge/wordrawidx/view/screens/GameScreen.kt
+++ b/app/src/main/java/fr/uge/wordrawidx/view/screens/GameScreen.kt
@@ -23,6 +23,7 @@ import fr.uge.wordrawidx.view.components.GameStatusCard
 import fr.uge.wordrawidx.viewmodel.GameViewModel
 import fr.uge.wordrawidx.viewmodel.GameViewModelFactory
 import nl.dionsegijn.konfetti.compose.BuildConfig
+import kotlin.random.Random
 
 @Composable
 fun GameScreen(
@@ -123,8 +124,17 @@ fun GameScreen(
                                 Log.i("GameScreen", "Mini-jeu préparé pour cellule $cellIdx - Position sauvegardée: ${gameState.playerPosition}")
 
                                 // ✅ TEMPORAIRE : Seulement ShakeGame activé
-                                Log.d("GameScreen", "Navigation vers ShakeGame (labyrinthe désactivé)")
-                                navigationController.navigateTo(Screen.ShakeGame)
+//                                Log.d("GameScreen", "Navigation vers ShakeGame (labyrinthe désactivé)")
+//                                navigationController.navigateTo(Screen.ShakeGame)
+                                // Choix aléatoire du mini-jeu (Shake ou Labyrinthe)
+                                val nextScreen = if (Random.nextBoolean()) {
+                                    Screen.ShakeGame
+                                } else {
+                                    Screen.AccelerometerMaze
+                                }
+                                Log.d("GameScreen", "Navigation vers $nextScreen (choix aléatoire)")
+                                navigationController.navigateTo(nextScreen)
+
                             } else {
                                 Log.d("GameScreen", "Case $cellIdx déjà révélée - Pas de challenge nécessaire")
                             }

--- a/app/src/main/java/fr/uge/wordrawidx/viewmodel/MazeGameViewModel.kt
+++ b/app/src/main/java/fr/uge/wordrawidx/viewmodel/MazeGameViewModel.kt
@@ -1,0 +1,32 @@
+package fr.uge.wordrawidx.viewmodel
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.ViewModel
+import fr.uge.wordrawidx.model.MazeState
+
+/**
+ * ViewModel dédié au mini-jeu du labyrinthe.
+ * Conserve l’instance de [MazeState] à travers les changements
+ * de configuration (rotation de l’écran, changement de langue, etc.).
+ */
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+class MazeGameViewModel : ViewModel() {
+
+    /** État courant du labyrinthe, persistant tant que le ViewModel vit. */
+    val mazeState: MazeState = MazeState()
+
+    /** Relance une partie : génère un nouveau labyrinthe et remet le timer. */
+    fun resetGame() {
+        // Il suffit de recréer l’état; Compose observera les nouvelles valeurs.
+        // (On pourrait aussi ajouter une méthode `reset()` dans MazeState.)
+        val newState = MazeState()
+        // Copier les références pour que les Composables observent le nouvel objet
+        // sans recréer le ViewModel.
+        mazeState.walls.clear()
+        mazeState.walls.addAll(newState.walls)
+        mazeState.ballPosition = newState.ballPosition
+        mazeState.timeLeftSeconds = newState.timeLeftSeconds
+        mazeState.currentMiniGameState = newState.currentMiniGameState
+    }
+}


### PR DESCRIPTION
### 1 / 4 — MazeGameViewModel.kt
```bash
feat(maze): add MazeGameViewModel to persist MazeState across rotations

* New ViewModel keeps a single MazeState instance alive through
  configuration changes.
* Adds resetGame() helper to regenerate a new maze only on user request.

### 2 / 4 — AccelerometerMazeScreen.kt
refactor(maze): use MazeGameViewModel instead of local remember{} state

* Replaces remember { MazeState() } with mazeViewModel.mazeState.
* Guarantees maze/map and timer survive activity recreation.

### 3 / 4 — AccelerometerMazeController.kt
fix(maze): preserve ball position & map on orientation change

* Introduce dimensionsInitialized flag to detect first setup.
* Recompute ballPosition in grid units, then re-project to new px
  dimensions instead of resetting to start.
* Prevents automatic maze regeneration on rotation.

### 4 / 4 — GameScreen.kt
feat(game): choose mini-game randomly between Shake and Maze

* Add kotlin.random.Random import.
* Replace hard-coded navigation to ShakeGame with 50/50 random pick
  between Screen.ShakeGame and Screen.AccelerometerMaze.
* Logs selected mini-game for debugging.